### PR TITLE
fix: correct capitalization in imports

### DIFF
--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Link from 'next/Link';
+import Link from 'next/link';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,5 @@
 import '@/styles/globals.css';
-import NavBar from '@/components/Navbar';
+import NavBar from '@/components/NavBar';
 
 export default function App({ Component, pageProps }) {
 	return (


### PR DESCRIPTION
Macs have a case-insensitive filesystem, while Linux doesn't (see <https://github.com/vercel/next.js/issues/9482#issuecomment-557114311>). This means that Macs will successfully run this code when the capitalization isn't correct. However, I'm developing on a Linux system, so this causes the code to have a build error and not run:

```
error - ./src/pages/_app.js:2:0
Module not found: Can't resolve '@/components/Navbar'
  1 | import '@/styles/globals.css';
> 2 | import NavBar from '@/components/Navbar';
  3 |
  4 | export default function App({ Component, pageProps }) {
  5 |   return (
```

This PR corrects the capitalization of the two faulty imports so it'll run on my machine.