### PR TITLE
fix(next.config): ignoreBuildCase goes under typescript

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  ignoreBuildErrors: true,
+  typescript: {
+    ignoreBuildErrors: true,
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
[ignoreBuildErrors goes under typescript](https://nextjs.org/docs/api-reference/next.config.js/ignoring-typescript-errors). Otherwise, `yarn dev` gives an error about invalid configuration.

The reason this setting is being enabled is to remove the need to learn TypeScript for this project.