### PR TITLE
chore: add .tool-versions, update README

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.7]
+        node-version: [19]
 
     steps:
       - uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+yarn 1
+node 19

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Roomies: A Roommate-Finding Web Application
 
+![The homepage of our app.](https://user-images.githubusercontent.com/47428697/225246052-b10f6e6e-441b-4822-8f6a-9b7a722dd00a.png)
+
+[See the app here!](https://roomie-green.vercel.app/)
+
 ## Background
 As a student at UCSD who are looking for housing, finding a roommate can be a challenging and time-consuming process for individuals seeking compatible living arrangements. It is difficult to find a roommate who aligns with personal preferences, lifestyle, and habits. The Roomies web app aims to simplify the roommate search process by providing a platform for users to find compatible roommates based on their preferences and lifestyle. The web app will help users find roommates who share similar interests, habits, and budgets.
 
-This project was developed by Mingyang Liu, Jiangnan Xu, Brittany Trieu, Aditya Barsainya, and Aidan Denlinger.
+This project was developed by Mingyang Liu, Jiangnan Xu, Brittany Trieu, Aditya Barsainya, and Aidan Denlinger [as a final project for CSE 210, taught by Michael Coblenz in Winter 2023](https://mcoblenz.github.io/CSE210/).
 
 ## Documentation
 See the project documentation in our [Github Wiki](https://github.com/CSE210-G13/my-roommates/wiki).


### PR DESCRIPTION
Some final housekeeping to make sure we can reproduce our dev environment in the future. If we want to show this project off but future `node` updates break this project, we want to know what version of `node` we were using during development (in this instance, 19) to go back to a stable environment.

Just as `package.json` tracks what versions of packages we're using, a `.tool-versions` file tracks what versions of compilers/tools are being used for the project. You can use it to manually check and download the required versions, but it can also be [a configuration file used by the runtime configuration tool asdf](https://asdf-vm.com/manage/configuration.html#tool-versions), its rust clone [rtx](https://github.com/jdxcode/rtx), or any other asdf compatible tool to automatically download/manage these dependencies.

This also unpins node 19.7, as 19.8.1 was released to fix nodejs/node#47096 (which is the issue we were running into).

Finally, added a link to our latest deployment and picture of the homepage so that the README has everything.